### PR TITLE
Add full outer join function

### DIFF
--- a/FullOuterJoin.ConsoleApp/FullOuterJoin.ConsoleApp.csproj
+++ b/FullOuterJoin.ConsoleApp/FullOuterJoin.ConsoleApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FullOuterJoin\FullOuterJoin.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FullOuterJoin.ConsoleApp/Program.cs
+++ b/FullOuterJoin.ConsoleApp/Program.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FullOuterJoin;
+
+namespace FullOuterJoin.ConsoleApp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var left = new List<(int Id, string Name)>
+            {
+                (1, "Left1"),
+                (2, "Left2"),
+                (3, "Left3")
+            };
+
+            var right = new List<(int Id, string Name)>
+            {
+                (2, "Right2"),
+                (3, "Right3"),
+                (4, "Right4")
+            };
+
+            var result = left.FullOuterJoin(
+                right,
+                l => l.Id,
+                r => r.Id,
+                (l, r, id) => new { Id = id, LeftName = l.Name, RightName = r.Name }
+            ).ToList();
+
+            foreach (var item in result)
+            {
+                Console.WriteLine($"Id: {item.Id}, LeftName: {item.LeftName}, RightName: {item.RightName}");
+            }
+        }
+    }
+}

--- a/FullOuterJoin.Tests/FullOuterJoin.Tests.csproj
+++ b/FullOuterJoin.Tests/FullOuterJoin.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/FullOuterJoin.Tests/FullOuterJoinTests.cs
+++ b/FullOuterJoin.Tests/FullOuterJoinTests.cs
@@ -1,0 +1,109 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FullOuterJoin;
+
+namespace FullOuterJoin.Tests
+{
+    [TestClass]
+    public class FullOuterJoinTests
+    {
+        [TestMethod]
+        public void FullOuterJoin_BothCollectionsHaveElements_ReturnsCorrectResult()
+        {
+            var left = new List<(int Id, string Name)>
+            {
+                (1, "Left1"),
+                (2, "Left2"),
+                (3, "Left3")
+            };
+
+            var right = new List<(int Id, string Name)>
+            {
+                (2, "Right2"),
+                (3, "Right3"),
+                (4, "Right4")
+            };
+
+            var result = left.FullOuterJoin(
+                right,
+                l => l.Id,
+                r => r.Id,
+                (l, r, id) => new { Id = id, LeftName = l.Name, RightName = r.Name }
+            ).ToList();
+
+            Assert.AreEqual(4, result.Count);
+            Assert.IsTrue(result.Any(r => r.Id == 1 && r.LeftName == "Left1" && r.RightName == null));
+            Assert.IsTrue(result.Any(r => r.Id == 2 && r.LeftName == "Left2" && r.RightName == "Right2"));
+            Assert.IsTrue(result.Any(r => r.Id == 3 && r.LeftName == "Left3" && r.RightName == "Right3"));
+            Assert.IsTrue(result.Any(r => r.Id == 4 && r.LeftName == null && r.RightName == "Right4"));
+        }
+
+        [TestMethod]
+        public void FullOuterJoin_LeftCollectionIsEmpty_ReturnsCorrectResult()
+        {
+            var left = new List<(int Id, string Name)>();
+
+            var right = new List<(int Id, string Name)>
+            {
+                (2, "Right2"),
+                (3, "Right3"),
+                (4, "Right4")
+            };
+
+            var result = left.FullOuterJoin(
+                right,
+                l => l.Id,
+                r => r.Id,
+                (l, r, id) => new { Id = id, LeftName = l.Name, RightName = r.Name }
+            ).ToList();
+
+            Assert.AreEqual(3, result.Count);
+            Assert.IsTrue(result.Any(r => r.Id == 2 && r.LeftName == null && r.RightName == "Right2"));
+            Assert.IsTrue(result.Any(r => r.Id == 3 && r.LeftName == null && r.RightName == "Right3"));
+            Assert.IsTrue(result.Any(r => r.Id == 4 && r.LeftName == null && r.RightName == "Right4"));
+        }
+
+        [TestMethod]
+        public void FullOuterJoin_RightCollectionIsEmpty_ReturnsCorrectResult()
+        {
+            var left = new List<(int Id, string Name)>
+            {
+                (1, "Left1"),
+                (2, "Left2"),
+                (3, "Left3")
+            };
+
+            var right = new List<(int Id, string Name)>();
+
+            var result = left.FullOuterJoin(
+                right,
+                l => l.Id,
+                r => r.Id,
+                (l, r, id) => new { Id = id, LeftName = l.Name, RightName = r.Name }
+            ).ToList();
+
+            Assert.AreEqual(3, result.Count);
+            Assert.IsTrue(result.Any(r => r.Id == 1 && r.LeftName == "Left1" && r.RightName == null));
+            Assert.IsTrue(result.Any(r => r.Id == 2 && r.LeftName == "Left2" && r.RightName == null));
+            Assert.IsTrue(result.Any(r => r.Id == 3 && r.LeftName == "Left3" && r.RightName == null));
+        }
+
+        [TestMethod]
+        public void FullOuterJoin_BothCollectionsAreEmpty_ReturnsEmptyResult()
+        {
+            var left = new List<(int Id, string Name)>();
+            var right = new List<(int Id, string Name)>();
+
+            var result = left.FullOuterJoin(
+                right,
+                l => l.Id,
+                r => r.Id,
+                (l, r, id) => new { Id = id, LeftName = l.Name, RightName = r.Name }
+            ).ToList();
+
+            Assert.AreEqual(0, result.Count);
+        }
+    }
+}

--- a/FullOuterJoin/FullOuterJoin.cs
+++ b/FullOuterJoin/FullOuterJoin.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FullOuterJoin
+{
+    public static class FullOuterJoin
+    {
+        public static IEnumerable<TResult> FullOuterJoin<TLeft, TRight, TKey, TResult>(
+            this IEnumerable<TLeft> left,
+            IEnumerable<TRight> right,
+            Func<TLeft, TKey> leftKeySelector,
+            Func<TRight, TKey> rightKeySelector,
+            Func<TLeft, TRight, TKey, TResult> resultSelector)
+        {
+            var leftLookup = left.ToLookup(leftKeySelector);
+            var rightLookup = right.ToLookup(rightKeySelector);
+
+            var leftKeys = new HashSet<TKey>(leftLookup.Select(g => g.Key));
+            var rightKeys = new HashSet<TKey>(rightLookup.Select(g => g.Key));
+
+            var allKeys = new HashSet<TKey>(leftKeys);
+            allKeys.UnionWith(rightKeys);
+
+            foreach (var key in allKeys)
+            {
+                var leftElements = leftLookup[key];
+                var rightElements = rightLookup[key];
+
+                if (leftElements.Any() && rightElements.Any())
+                {
+                    foreach (var leftElement in leftElements)
+                    {
+                        foreach (var rightElement in rightElements)
+                        {
+                            yield return resultSelector(leftElement, rightElement, key);
+                        }
+                    }
+                }
+                else if (leftElements.Any())
+                {
+                    foreach (var leftElement in leftElements)
+                    {
+                        yield return resultSelector(leftElement, default, key);
+                    }
+                }
+                else
+                {
+                    foreach (var rightElement in rightElements)
+                    {
+                        yield return resultSelector(default, rightElement, key);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/FullOuterJoin/FullOuterJoin.csproj
+++ b/FullOuterJoin/FullOuterJoin.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # csharp-interview-question
+
+## Full Outer Join LINQ Function
+
+This project provides a LINQ compatible function that performs a full outer join between two enumerables.
+
+### How to Use the Full Outer Join Function
+
+1. Add the `FullOuterJoin` class library to your project.
+2. Use the `FullOuterJoin` function as an extension method on your enumerables.
+
+Example:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FullOuterJoin;
+
+class Program
+{
+    static void Main()
+    {
+        var left = new List<(int Id, string Name)>
+        {
+            (1, "Left1"),
+            (2, "Left2"),
+            (3, "Left3")
+        };
+
+        var right = new List<(int Id, string Name)>
+        {
+            (2, "Right2"),
+            (3, "Right3"),
+            (4, "Right4")
+        };
+
+        var result = left.FullOuterJoin(
+            right,
+            l => l.Id,
+            r => r.Id,
+            (l, r, id) => new { Id = id, LeftName = l.Name, RightName = r.Name }
+        ).ToList();
+
+        foreach (var item in result)
+        {
+            Console.WriteLine($"Id: {item.Id}, LeftName: {item.LeftName}, RightName: {item.RightName}");
+        }
+    }
+}
+```
+
+### How to Run the Console Application
+
+1. Open the solution file `csharp-interview-question.sln` in Visual Studio.
+2. Set `FullOuterJoin.ConsoleApp` as the startup project.
+3. Run the project.
+
+The console application will demonstrate the full outer join function by joining two sample lists and printing the result to the console.

--- a/csharp-interview-question.sln
+++ b/csharp-interview-question.sln
@@ -1,0 +1,33 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FullOuterJoin", "FullOuterJoin\FullOuterJoin.csproj", "{8A2A1A1B-5A1A-4A1A-8A1A-1A1A1A1A1A1A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FullOuterJoin.Tests", "FullOuterJoin.Tests\FullOuterJoin.Tests.csproj", "{9B3B2B2B-6B2B-4B2B-9B2B-2B2B2B2B2B2B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FullOuterJoin.ConsoleApp", "FullOuterJoin.ConsoleApp\FullOuterJoin.ConsoleApp.csproj", "{AC4C3C3C-7C3C-4C3C-AC3C-3C3C3C3C3C3C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8A2A1A1B-5A1A-4A1A-8A1A-1A1A1A1A1A1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A2A1A1B-5A1A-4A1A-8A1A-1A1A1A1A1A1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A2A1A1B-5A1A-4A1A-8A1A-1A1A1A1A1A1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A2A1A1B-5A1A-4A1A-8A1A-1A1A1A1A1A1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B3B2B2B-6B2B-4B2B-9B2B-2B2B2B2B2B2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B3B2B2B-6B2B-4B2B-9B2B-2B2B2B2B2B2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B3B2B2B-6B2B-4B2B-9B2B-2B2B2B2B2B2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B3B2B2B-6B2B-4B2B-9B2B-2B2B2B2B2B2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC4C3C3C-7C3C-4C3C-AC3C-3C3C3C3C3C3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC4C3C3C-7C3C-4C3C-AC3C-3C3C3C3C3C3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC4C3C3C-7C3C-4C3C-AC3C-3C3C3C3C3C3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC4C3C3C-7C3C-4C3C-AC3C-3C3C3C3C3C3C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Add a new C# dotnet project to provide a LINQ compatible function for a full outer join between two enumerables.

* **Solution and Project Files**
  - Add `csharp-interview-question.sln` solution file.
  - Add `FullOuterJoin/FullOuterJoin.csproj` class library project file.
  - Add `FullOuterJoin.Tests/FullOuterJoin.Tests.csproj` test project file.
  - Add `FullOuterJoin.ConsoleApp/FullOuterJoin.ConsoleApp.csproj` console application project file.

* **Full Outer Join Implementation**
  - Add `FullOuterJoin/FullOuterJoin.cs` with the `FullOuterJoin` class and the LINQ compatible function for full outer join.

* **Unit Tests**
  - Add `FullOuterJoin.Tests/FullOuterJoinTests.cs` with unit tests for the full outer join function.

* **Console Application**
  - Add `FullOuterJoin.ConsoleApp/Program.cs` with a console application to demonstrate the full outer join function.

* **Documentation**
  - Update `README.md` with a description of the project, instructions on how to use the full outer join function, and how to run the console application.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TopperKain/csharp-interview-question/pull/1?shareId=ed9b4638-2986-449d-ae30-ec7b41b75001).